### PR TITLE
Add support for configuring the output folder via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ prom-rancher-sd polls [Rancher's metadata service](http://docs.rancher.com/ranch
 
 A configuration file suitable for use by [Prometheus](http://prometheus.io/) is written to enable services to be monitored automatically. 
 
+The configuration file will be written to the directory `/prom-rancher-sd-data` by default, use the `OUTPUT_FOLDER` environment variable to change the directory.
 
 I changed a bit the cowhand approach by enriching the labels and assigning some sensible defaults. 
 

--- a/prom-rancher-sd.py
+++ b/prom-rancher-sd.py
@@ -85,6 +85,6 @@ def write_config_file(filename,get_config_function):
 if __name__ == '__main__':
     while True:
         time.sleep(5)
-        write_config_file(outputFolder + '/rancher.json',get_monitoring_config)
-        write_config_file(outputFolder + '/node_exporter.json',get_node_monitoring_config)
+        write_config_file('{0}/rancher.json'.format(outputFolder),get_monitoring_config)
+        write_config_file('{0}/node_exporter.json'.format(outputFolder),get_node_monitoring_config)
 

--- a/prom-rancher-sd.py
+++ b/prom-rancher-sd.py
@@ -8,7 +8,9 @@ import urllib.parse
 import urllib.request
 import json
 import shutil
+import os
 
+outputFolder=os.getenv('OUTPUT_FOLDER', '/prom-rancher-sd-data').rstrip('/')
 
 def get_current_metadata_entry(entry):
     headers = {
@@ -83,6 +85,6 @@ def write_config_file(filename,get_config_function):
 if __name__ == '__main__':
     while True:
         time.sleep(5)
-        write_config_file('/prom-rancher-sd-data/rancher.json',get_monitoring_config)
-        write_config_file('/prom-rancher-sd-data/node_exporter.json',get_node_monitoring_config)
+        write_config_file(outputFolder + '/rancher.json',get_monitoring_config)
+        write_config_file(outputFolder + '/node_exporter.json',get_node_monitoring_config)
 


### PR DESCRIPTION
This PR adds the `OUTPUT_FOLDER` environment variable which allows the user to specify where the configuration files will written.