### PR TITLE
Use __metrics_path__ instead of metrics_path

### DIFF
--- a/prom-rancher-sd.py
+++ b/prom-rancher-sd.py
@@ -39,7 +39,7 @@ def monitoring_config(service):
             'name': service['name'],
             'service_name': service['service_name'],
             'stack_name': service['stack_name'],
-            'metrics_path': service['labels']['com.prometheus.metricspath'] if 'com.prometheus.metricspath' in service['labels'] else '/metrics'
+            '__metrics_path__': service['labels']['com.prometheus.metricspath'] if 'com.prometheus.metricspath' in service['labels'] else '/metrics'
         },
        "host-uuid": service['host_uuid']
     }


### PR DESCRIPTION
When I set the `com.prometheus.metricspath` label in my services to override the metrics path used by prometheus it still tries to poll the default `/metrics` endpoint.

This is due to using the `metrics_path` label which prometheus does not use, instead it uses `__metrics_path__`.

This PR changes to the proper label.

[This behavior is described by the prometheus maintainer here.](https://groups.google.com/forum/#!topic/prometheus-users/i_nmaybtPwE)